### PR TITLE
Add 'importPath' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath) {
   var fontsDir       = options.fontsDir       || 'fonts';
   var require        = options.require        || 'sass-css-importer'; // this allows us to import CSS files with @import("CSS:path")
   var compassCommand = options.compassCommand || 'compass';
+  var importPath     = options.importPath     || [];
 
   var compassOptions = {
     outputStyle: outputStyle,
@@ -32,7 +33,8 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath) {
     imagesDir: imagesDir,
     fontsDir: fontsDir,
     cssDir: cssDir,
-    compassCommand: compassCommand
+    compassCommand: compassCommand,
+    importPath: importPath
   };
 
   tree = mergeTrees([tree, 'public'], {


### PR DESCRIPTION
Added the importPath compass compiler option which allows us to specify custom paths that should be searched when using the @import statement. Allows you to easily include frameworks like foundation by using (is there better way than this?): 

```
var app = new EmberApp({
    compassOptions: {
        importPath: [
            process.cwd() + '/vendor/foundation/scss'
        ]
    }
});
```
