### PR TITLE
Don't force users to require saas-css-importer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath) {
   var cssDir         = options.cssDir         || outputPath;
   var imagesDir      = options.imagesDir      || 'images';
   var fontsDir       = options.fontsDir       || 'fonts';
-  var require        = options.require        || 'sass-css-importer'; // this allows us to import CSS files with @import("CSS:path")
+  var require        = options.require;
   var compassCommand = options.compassCommand || 'compass';
 
   var compassOptions = {


### PR DESCRIPTION
Even if `options.require` is explicitly set to `null` `sass-css-importer` was required. The command would failed if the dependency was not satisfied.

I believed that the Readme is detailed enough to explain how to require `sass-css-importer`. That change will permit user who don't want to install that dependency to use this library as well.
