### PR TITLE
Add support for relativeAssets option

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath) {
 
   var options        = this.options;
   var mainFile       = options.mainFile       || (this.appName + '.' + this.ext);
+  var relativeAssets = options.relativeAssets !== undefined ? options.relativeAssets : true;
   var outputStyle    = options.outputStyle    || 'compressed'; // or expanded
   var sassDir        = options.sassDir        || inputPath;
   var cssDir         = options.cssDir         || outputPath;
@@ -25,6 +26,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath) {
   var compassCommand = options.compassCommand || 'compass';
 
   var compassOptions = {
+    relativeAssets: relativeAssets,
     outputStyle: outputStyle,
     require: options.require,
     importPath: options.importPath,


### PR DESCRIPTION
Add support for relativeAssets, a boolean option, defaulting to true.

The default value matches broccoli-compass’ default for this option, so this
should not change behavior of existing apps.
