### PR TITLE
Upgrade broccoli-compass to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "readmeFile": "README.md",
   "dependencies": {
-    "broccoli-compass": "0.0.9",
+    "broccoli-compass": "0.1.0",
     "broccoli-merge-trees": "^0.1.4",
     "lodash-node": "^2.4.1"
   }


### PR DESCRIPTION
This version has better support for filesystems that cannot symlink.
