### PR TITLE
Live reload when importPaths change

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ var app = new EmberApp({
 });
 ```
 
+### Import paths
+
+You can add additional scss import paths in your `compassOptions`. These paths will also be watched by broccoli and reload live.
+
+```javascript
+var app = new EmberApp({
+  compassOptions: {
+    importPath: ['/full/path/to/scss/dir', '/other/full/path/to/css/dir']
+  }
+});
+```
+
+
 ### References
 
 * [compass](http://compass-style.org/)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-var compile    = require('./compiler');
-var merge      = require('lodash-node/modern/objects/merge');
+var compile       = require('./compiler');
+var merge         = require('lodash-node/modern/objects/merge');
+var mergeTrees    = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-cli-compass-compiler',
@@ -22,11 +23,19 @@ module.exports = {
           sassDir: inputPath,
           cssDir: outputPath,
           outputStyle: 'compressed',
-          compassCommand: 'compass'
+          compassCommand: 'compass',
+          importPath: []
         };
 
         var compassOptions = merge(defaultOptions, options);
-        return compile(inputPath, compassOptions);
+
+        var treesToWatch = compassOptions.importPath.map(function (path) {
+          var relativePath = path.replace(process.cwd() + '/', '');
+          return relativePath;
+        })
+        treesToWatch.unshift(inputPath);
+        var merged = mergeTrees(treesToWatch, { overwrite: true });
+        return compile(merged, compassOptions);
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "broccoli-caching-writer": "^0.4.2",
     "dargs": "^2.0.3",
     "lodash-node": "^2.4.1",
-    "rsvp": "^3.0.13"
+    "rsvp": "^3.0.13",
+    "broccoli-merge-trees": "^0.2.1"
   }
 }


### PR DESCRIPTION
Providing importPaths option was not previously live reloading when files at those import paths changed. These changes mean the livereload works.