### PR TITLE
Use supplied tree

### DIFF
--- a/compass.js
+++ b/compass.js
@@ -11,9 +11,9 @@ function Compass() {
 }
 
 Compass.prototype.generateCommand = function(options) {
-  var ignoredOptions = ['compassCommand'];
+  var ignoredOptions = ['compassCommand', 'files'];
   var args = dargs(options, ignoredOptions);
-  var command = [options.compassCommand, 'compile'].concat(args).join(' ');
+  var command = [options.compassCommand, 'compile'].concat(args).concat(options.files).join(' ');
   return command;
 };
 

--- a/index.js
+++ b/index.js
@@ -21,12 +21,13 @@ module.exports = {
         var defaultOptions = {
           sassDir: inputPath,
           cssDir: outputPath,
+          importPath: '.',
           outputStyle: 'compressed',
           compassCommand: 'compass'
         };
 
         var compassOptions = merge(defaultOptions, options);
-        return compile(inputPath, compassOptions);
+        return compile(tree, compassOptions);
       }
     });
   }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var compile    = require('./compiler');
 var merge      = require('lodash-node/modern/objects/merge');
-var pickFiles  = require('broccoli-static-compiler');
 var RSVP       = require('rsvp');
 var fs         = require('fs');
 var path       = require('path');

--- a/index.js
+++ b/index.js
@@ -1,10 +1,16 @@
 var compile    = require('./compiler');
 var merge      = require('lodash-node/modern/objects/merge');
+var pickFiles  = require('broccoli-static-compiler');
+var RSVP       = require('rsvp');
+var fs         = require('fs');
+var path       = require('path');
 
 module.exports = {
   name: 'ember-cli-compass-compiler',
   included: function(app) {
     this._super.included.apply(this, arguments);
+    var projectName = this.project.name();
+
     app.registry.add('css', {
       name: 'ember-cli-compass-compiler',
       ext: ['scss', 'sass'],
@@ -22,12 +28,34 @@ module.exports = {
           sassDir: inputPath,
           cssDir: outputPath,
           importPath: '.',
+          files: [inputPath + '/app.scss'],
           outputStyle: 'compressed',
           compassCommand: 'compass'
         };
 
         var compassOptions = merge(defaultOptions, options);
-        return compile(tree, compassOptions);
+        var compiledTree = compile(tree, compassOptions);
+        return {
+          read: function(readTree) {
+            return readTree(compiledTree).then(function(srcDir) {
+              return new RSVP.Promise(function (resolve, reject) {
+                var srcPath = path.join(srcDir, 'assets', 'app.css');
+                var destPath = path.join(srcDir, 'assets', projectName + '.css');
+                fs.rename(srcPath, destPath, function(err) {
+                  if (err) {
+                    reject(err);
+                  }
+                  resolve(srcDir);
+                })
+              });
+            });
+          },
+          cleanup: function() {
+            if (typeof compiledTree.cleanup === 'function') {
+              return compiledTree.cleanup();
+            }
+          }
+        }
       }
     });
   }


### PR DESCRIPTION
Per [the Ember CLI docs](http://www.ember-cli.com/#dynamic-styles-scss-less-etc) I should be able to reference `bower_components` from my import files, like so:

> @import "bower_components/foundation/scss/normalize.scss";

The current version of the compass add on does not support this, because the vendor tree is not being passed to the compiler class.

This change adds support for referencing the bower_components tree by passing the source tree to the compiler, and providing the `importPath` option to compass to allow imports to references files in the vendor trees.