### PR TITLE
Respect ember-cli outputPaths

### DIFF
--- a/compass.js
+++ b/compass.js
@@ -5,26 +5,23 @@ var merge = require('lodash-node/modern/objects/merge');
 var path  = require('path');
 var RSVP  = require('rsvp');
 var sys   = require('sys');
+var fs    = require('fs');
 
-function Compass() {
-
-}
+function Compass() {};
 
 Compass.prototype.generateCommand = function(options) {
-  var ignoredOptions = ['compassCommand'];
-  var args = dargs(options, ignoredOptions);
-  var command = [options.compassCommand, 'compile'].concat(args).join(' ');
+  var ignoredOptions = ['compassCommand', 'inputFile', 'outputFile'];
+  var args = dargs(options, { excludes: ignoredOptions });
+  var command = [options.compassCommand, 'compile', options.Fileinput].concat(args).join(' ');
+
   return command;
 };
 
 Compass.prototype.compile = function(srcDir, destDir, options) {
-  var cssDir  = path.join(destDir, 'assets');
-
-  merge(options, {
-    cssDir: "'"+cssDir+"'"
-  });
-
-  var command = this.generateCommand(options);
+  var cssDir  = path.join(destDir, options.cssDir);
+  var outputFile = options.outputFile;
+  var outputFileName = outputFile.substring(outputFile.lastIndexOf('/') + 1, outputFile.length);
+  var command = this.generateCommand(merge({}, options, { cssDir: cssDir }));
 
   return new RSVP.Promise(function(resolve, reject) {
     exec(command, function(error, stdout, stderr) {
@@ -36,6 +33,7 @@ Compass.prototype.compile = function(srcDir, destDir, options) {
         sys.print(stdout + EOL);
         reject(error);
       } else {
+        fs.renameSync(cssDir + 'app.css', cssDir + outputFileName);
         resolve(cssDir);
       }
     });

--- a/compiler.js
+++ b/compiler.js
@@ -1,18 +1,20 @@
-var Writer  = require('broccoli-caching-writer');
+var CachingWriter  = require('broccoli-caching-writer');
 var Compass = require('./compass');
 
 module.exports = CompassCompiler;
-CompassCompiler.prototype = Object.create(Writer.prototype);
+CompassCompiler.prototype = Object.create(CachingWriter.prototype);
 CompassCompiler.prototype.constructor = CompassCompiler;
 
-function CompassCompiler(inputTree, options) {
-  this.options = options || {};
-  if (!(this instanceof CompassCompiler)) return new CompassCompiler(inputTree, options);
+function CompassCompiler(sourceTrees, options) {
+  if (!(this instanceof CompassCompiler)) return new CompassCompiler(sourceTrees, options);
 
-  this.inputTree = inputTree;
-  this.compass = new Compass();
+  CachingWriter.apply(this, arguments);
+
+  this.sourceTrees = sourceTrees;
+  this.options = options || {};
 }
 
 CompassCompiler.prototype.updateCache = function(srcDir, destDir) {
-  return this.compass.compile(srcDir, destDir, this.options);
+  compass = new Compass();
+  return compass.compile(srcDir, destDir, this.options);
 };

--- a/index.js
+++ b/index.js
@@ -1,33 +1,50 @@
 var compile    = require('./compiler');
 var merge      = require('lodash-node/modern/objects/merge');
+var path       = require('path');
+var mergeTrees = require('broccoli-merge-trees');
+var fs         = require('fs');
 
-module.exports = {
-  name: 'ember-cli-compass-compiler',
-  included: function(app) {
-    this._super.included.apply(this, arguments);
-    app.registry.add('css', {
-      name: 'ember-cli-compass-compiler',
-      ext: ['scss', 'sass'],
-      toTree: function(tree, inputPath, outputPath) {
-        if (inputPath[0] === '/') {
-          inputPath = inputPath.slice(1);
-        }
+function CompassCompilerPlugin(options) {
+  this.name = 'ember-cli-compass-compiler';
+  this.ext = ['scss', 'sass'];
+  this.options = merge({
+    compassCommand: 'compass',
+    outputStyle: 'compressed'
+  }, options);
 
-        if (outputPath[0] === '/') {
-          outputPath = outputPath.slice(1);
-        }
+}
 
-        var options = app.options.compassOptions || {};
-        var defaultOptions = {
-          sassDir: inputPath,
-          cssDir: outputPath,
-          outputStyle: 'compressed',
-          compassCommand: 'compass'
-        };
+CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
+  options = merge({}, this.options, options);
+  inputPath = (inputPath[0] === '/') ? inputPath.slice(1) : inputPath;
+  outputPath = (outputPath[0] === '/') ? outputPath.slice(1) : outputPath;
 
-        var compassOptions = merge(defaultOptions, options);
-        return compile(inputPath, compassOptions);
-      }
+  var paths = options.outputPaths;
+  var trees = Object.keys(paths).map(function(file) {
+    var input = path.join(inputPath, file + '.');
+    input += (fs.existsSync(input + this.ext[0])) ? this.ext[0] : this.ext[1];
+
+    merge(options, {
+      inputFile: input,
+      outputFile: paths[file],
+      sassDir: inputPath,
+      cssDir: paths[file].substring(0, paths[file].lastIndexOf('/') + 1)
     });
-  }
-};
+
+    return compile([tree], options);
+  }.bind(this));
+  
+  return mergeTrees(trees);
+}
+
+function EmberCLICompassCompiler(project) {
+  this.project = project;
+  this.name = "Ember CLI Compass Compiler";
+}
+
+EmberCLICompassCompiler.prototype.included = function included(app) {
+  var options = app.options.compassOptions || {};
+  app.registry.add('css', new CompassCompilerPlugin(options));
+}
+
+module.exports = EmberCLICompassCompiler;

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
   "license": "MIT",
   "readmeFile": "README.md",
   "dependencies": {
-    "broccoli-caching-writer": "^0.4.2",
-    "dargs": "^2.0.3",
+    "broccoli-caching-writer": "^0.5.4",
+    "dargs": "^4.0.0",
     "lodash-node": "^2.4.1",
-    "rsvp": "^3.0.13"
+    "rsvp": "^3.0.13",
+    "broccoli-merge-trees": "^0.2.1"
   }
 }


### PR DESCRIPTION
Heavily inspired by this [ember-cli-commit](https://github.com/gdub22/ember-cli-less/commit/04418f39cc65aff02f030e78c948a390a60ebe1a#diff-168726dbe96b3ce427e7fedce31bb0bcR40). I've tested it a few times with `ember-cli 0.1.14` and everything looks and works pretty sweet...

The only issue I'm still having is passing more than 1 css file in an outputPaths like:
```js
var app = new EmberApp({
  outputPaths: {
    app: {
      css: {
        'app': '/custom_assets/dyo.css',
        'cool': '/custom_assets/cool.css'
      }
    }
  }
});
```

The issue seems to be around line 24 of index.js where we use `Array.prototype.map`. The map returns an array of objects as it should but the objects are identical... I'm assuming it has something to do with an async issue but I'm kind of stumped.

Anyway, this still works better than the original.


