### PR TITLE
Fixes #26. Quote cssDir argument to allow spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
     compassCommand: 'compass',
     importPath: [],
     getCssDir: function(outputDir) {
-      return path.join(outputDir, outputPath);
+      return '"' + path.join(outputDir, outputPath) + '"';
     }
   };
   var compassOptions = merge({}, defaultOptions, this.optionsFn(), inputOptions);


### PR DESCRIPTION
Bug was causing the following error message:
    Error: Command failed: Individual stylesheets must be in the sass directory.