### PR TITLE
Ember CLI Addon Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ember install ember-cli-compass-compiler
 > **Note:** This addon will compile your `.scss` files, in addition to making Compass's
   libraries available to your project. This means you **do not** need additional broccoli libraries
   for compiling sass, such as `broccoli-sass`.
-  
+
 > Be sure to remove all such libraries from your project when using `ember-cli-compass-compiler`.
 
 ### Requirements
@@ -30,8 +30,8 @@ gem install compass
 
 After installation everything should work automatically.
 
-`app.scss` in your `app/styles` directory is compiled into `assets/appname.css` 
-with `ember build` or `ember serve` commands. Other `.scss` files in `app/styles` 
+`app.scss` in your `app/styles` directory is compiled into `assets/appname.css`
+with `ember build` or `ember serve` commands. Other `.scss` files in `app/styles`
 are compiled as well.
 
 > **Note:** Previous versions of this addon(< 0.1.0) was requiring the main `.scss` file to be named as `appname.scss`.
@@ -53,7 +53,7 @@ To use compass, import it in your `app.scss`:
 @import "compass";
 
 .round-rect-button {
-  @include border-radius(4px, 4px); 
+  @include border-radius(4px, 4px);
 }
 ```
 
@@ -99,6 +99,68 @@ var app = new EmberApp({
   }
 });
 ```
+
+### Ember CLI Addon Usage
+
+If you are developing an Ember CLI Addon, you must follow these additional
+steps:
+
+1. Include your styles in `addon/styles/addon.scss` (`.sass` works as well)
+
+2. You can either install `ember-cli-compass-compiler` via NPM:
+
+  ```bash
+  $ npm install --save ember-cli-compass-compiler
+  ```
+
+  or make sure to move it to `dependencies` from `devDependencies` in your
+  `package.json` if already installed via
+  `ember install ember-cli-compass-compiler` command:
+
+  ```javascript
+  "dependencies": {
+    ...
+    "ember-cli-compass-compiler": "^0.4.0",
+    ...
+  }
+  ```
+
+  > **Important:** If you omit this step, Ember CLI will compile
+  `tests/dummy/app/styles/app.scss` for your dummy test application but not
+  your primary stylesheet at `addon/styles/addon.css`.
+
+3. In `./index.js` of your project, make sure an `included` function is defined:
+
+  ```javascript
+  'use strict'
+
+  module.exports = {
+    name: 'my-addon',
+    included: function(app) {
+      this._super.included(app);
+
+      // OPTIONAL: import your addon dependencies from bower_components
+      // app.import(`${app.bowerDirectory}/bootstrap/dist/js/bootstrap.js`);
+    }
+  };
+  ```
+
+  Without this, Ember CLI will throw an error when trying to serve the dummy
+  test application or building distributables:
+
+  ```
+  Cannot read property 'compassOptions' of undefined
+  TypeError: Cannot read property 'compassOptions' of undefined
+  ```
+
+4. Ensure your dummy test application contains `app.scss`.
+
+5. Run `ember build`. Your stylesheet at `addon/styles/addon.scss` will be
+  compiled to `dist/assets/vendor.css` and your test app's stylesheet at
+  `tests/dummy/app/styles/app.scss` will be compiled to `dist/assets/dummy.css`.
+
+For more information, refer to [Developing Addons and Blueprints](http://ember-cli.com/extending/#developing-addons-and-blueprints)
+section on the [Ember CLI website](http://ember-cli.com).
 
 ### References
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var compileCompass = require('broccoli-compass-compiler');
 var checker = require('ember-cli-version-checker');
 var mergeTrees = require('broccoli-merge-trees');
 var Funnel = require('broccoli-funnel');
+var glob = require('glob');
 
 function CompassCompilerPlugin(optionsFn) {
   this.name = 'ember-cli-compass-compiler';

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ module.exports = {
   compassOptions: function () {
     var app = this.app;
 
-    if (!app.options && app.app) {
+    if (app && !app.options && app.app) {
       app = app.app;
     }
 

--- a/index.js
+++ b/index.js
@@ -113,6 +113,12 @@ module.exports = {
   },
 
   compassOptions: function () {
-    return (this.app && this.app.options.compassOptions) || {};
+    var app = this.app;
+
+    if (!app.options && app.app) {
+      app = app.app;
+    }
+
+    return (app && app.options && app.options.compassOptions) || {};
   }
 };

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
 
 
   var outputPaths = compassOptions.outputPaths;
-  var trees = Object.keys(outputPaths).reduce(function(trees, file) {
+  var trees = Object.keys(outputPaths).map(function(file) {
 
     // Watch inputTrees and compassOptions.importPath directories
     var inputTrees = [tree];
@@ -82,9 +82,8 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
         return relativePath;
       }
     });
-    trees.push(node);
-    return trees;
-  }, []);
+    return node;
+  });
 
   return mergeTrees(trees);
 };

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
   var trees = Object.keys(outputPaths).reduce(function(trees, file) {
 
     // Watch inputTrees and compassOptions.importPath directories
-    var inputTrees = [inputPath];
+    var inputTrees = [tree];
 
     // Compile
     var compassTree = compileCompass(inputTrees, compassOptions);

--- a/index.js
+++ b/index.js
@@ -72,11 +72,13 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
     var outputFileName = path.basename(outputPaths[file], extension) + extension; // new name for asset
     var outputDir = removeLeadingSlash(path.dirname(outputPaths[file])); // new directory for asset
     var node = new Funnel(compassTree, {
-      srcDir: outputPath,
       destDir: outputDir,
       files: [fileName],
       getDestinationPath: function(relativePath) {
-        if (relativePath === path.join(this.destDir, fileName)) { return path.join(this.destDir, outputFileName); }
+        if (relativePath === path.join(this.destDir, fileName)) {
+          return path.join(this.destDir, outputFileName);
+        }
+
         return relativePath;
       }
     });

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
 
           return '';
         }, '');
-      }
+      };
     }
 
     // Compile

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
     // Define getSassDir function if not overridden by user
     if (!compassOptions.getSassDir) {
       compassOptions.getSassDir = function(inputTrees, inputPaths) {
-        return path.dirname(inputPaths.reduce(function(pathFound, currentPath) {
+        return inputPaths.reduce(function(pathFound, currentPath) {
           // Return early if input path is already found
           if (pathFound !== '') {
             return pathFound;
@@ -55,11 +55,11 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
 
           // Found the file we're looking for
           if (result.length > 0) {
-            return result[0];
+            return path.dirname(result[0]);
           }
 
           return '';
-        }, ''));
+        }, '');
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,29 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
     // Watch inputTrees and compassOptions.importPath directories
     var inputTrees = [tree];
 
+    // Define getSassDir function if not overridden by user
+    if (!compassOptions.getSassDir) {
+      compassOptions.getSassDir = function(inputTrees, inputPaths) {
+        return path.dirname(inputPaths.reduce(function(pathFound, currentPath) {
+          // Return early if input path is already found
+          if (pathFound !== '') {
+            return pathFound;
+          }
+
+          // Filter pattern for .sass or .scss files
+          var pattern = path.join(currentPath, inputPath, file + '.s@(a|c)ss');
+          var result = glob.sync(pattern);
+
+          // Found the file we're looking for
+          if (result.length > 0) {
+            return result[0];
+          }
+
+          return '';
+        }, ''));
+      }
+    }
+
     // Compile
     var compassTree = compileCompass(inputTrees, compassOptions);
 

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ CompassCompilerPlugin.prototype.toTree = function(tree, inputPath, outputPath, i
     var outputFileName = path.basename(outputPaths[file], extension) + extension; // new name for asset
     var outputDir = removeLeadingSlash(path.dirname(outputPaths[file])); // new directory for asset
     var node = new Funnel(compassTree, {
+      srcDir: outputPath,
       destDir: outputDir,
       files: [fileName],
       getDestinationPath: function(relativePath) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/quaertym/ember-cli-compass-compiler/issues"
   },
   "author": "Emre Unal",
+  "contributors": [
+    "Andrew Jo <andrewjo@gmail.com> (https://github.com/AndrewJo)"
+  ],
   "license": "MIT",
   "readmeFile": "README.md",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "broccoli-funnel": "0.2.11",
     "broccoli-merge-trees": "^0.2.3",
     "ember-cli-version-checker": "^1.1.4",
+    "glob": "^6.0.4",
     "merge": "^1.2.0"
   }
 }


### PR DESCRIPTION
This PR adds much needed support for Ember CLI Addon projects that wish to use Compass compilers. Once merged in, the minor version should be bumped (0.3.2 → 0.4.0) and published to NPM.

## Major Changes

- Input tree for the Broccoli Compass Compiler has changed: `[inputPath]` → `[tree]`.

  This ensures that `ember-cli-compass-compiler` correctly checks for files in `addon/styles`.

- Adds `getSassDir` function to correctly search the input paths

  Without this, the compiler throws an ENOENT error about missing files/directory.

See #47.